### PR TITLE
Allow changing voice volume

### DIFF
--- a/configurator/MainDialog.cpp
+++ b/configurator/MainDialog.cpp
@@ -80,6 +80,9 @@ void MainDialog::OnInitDialog() {
     hSliderWordgap_ = GetDlgItem(hwnd_, IDC_SLIDER_WORDGAP);
     hLabelWordgap_ = GetDlgItem(hwnd_, IDC_LABEL_WORDGAP);
     hCheckRateboost_ = GetDlgItem(hwnd_, IDC_CHECK_RATEBOOST);
+    hSliderVolume_ = GetDlgItem(hwnd_, IDC_SLIDER_VOLUME);
+    hLabelVolume_ = GetDlgItem(hwnd_, IDC_LABEL_VOLUME);
+
     hListProfiles_ = GetDlgItem(hwnd_, IDC_LIST_PROFILES);
     hBtnRemoveProfile_ = GetDlgItem(hwnd_, IDC_BTN_REMOVE_PROFILE);
 
@@ -97,6 +100,10 @@ void MainDialog::OnInitDialog() {
 
     SendMessage(hSliderWordgap_, TBM_SETRANGE, TRUE, MAKELPARAM(0, 100));
     SendMessage(hSliderWordgap_, TBM_SETTICFREQ, 10, 0);
+
+    SendMessage(hSliderVolume_, TBM_SETRANGE, TRUE, MAKELPARAM(0, 100));
+    SendMessage(hSliderVolume_, TBM_SETTICFREQ, 10, 0);
+
 
     LoadConfiguration();
     PopulateVariantCombo();
@@ -152,6 +159,8 @@ void MainDialog::OnHScroll(WPARAM wParam, LPARAM lParam) {
         UpdateIntonationLabel();
     } else if (hSlider == hSliderWordgap_) {
         UpdateWordgapLabel();
+    } else if (hSlider == hSliderVolume_) {
+        UpdateVolumeLabel();
     }
 }
 
@@ -175,6 +184,8 @@ void MainDialog::LoadConfiguration() {
     SendMessage(hSliderWordgap_, TBM_SETPOS, TRUE, config_.wordgap);
     UpdateWordgapLabel();
     SendMessage(hCheckRateboost_, BM_SETCHECK, config_.rateboost ? BST_CHECKED : BST_UNCHECKED, 0);
+    SendMessage(hSliderVolume_, TBM_SETPOS, TRUE, config_.volume);
+    UpdateVolumeLabel();
 }
 
 void MainDialog::SaveConfiguration() {
@@ -202,12 +213,13 @@ void MainDialog::SaveConfiguration() {
     config_.intonation = SendMessage(hSliderIntonation_, TBM_GETPOS, 0, 0);
     config_.wordgap = SendMessage(hSliderWordgap_, TBM_GETPOS, 0, 0);
     config_.rateboost = (SendMessage(hCheckRateboost_, BM_GETCHECK, 0, 0) == BST_CHECKED);
+    config_.volume = SendMessage(hSliderVolume_, TBM_GETPOS, 0, 0);
     config::ConfigManager& mgr = config::ConfigManager::getInstance();
     if (mgr.save(config_)) {
         MessageBox(hwnd_,
                    L"Configuration saved successfully.\n\n"
                    L"Changes take effect:\n"
-                   L"\u2022 Intonation/Word gap/Rate boost: Immediately for new speech\n"
+                   L"\u2022 Intonation/Word gap/Rate boost / volume: Immediately for new speech\n"
                    L"\u2022 Voice list/variants: Require restarting SAPI applications\n\n"
                    L"Applications using eSpeak-NG (screen readers, TTS software)\n"
                    L"will automatically detect parameter changes.",
@@ -353,6 +365,14 @@ void MainDialog::UpdateWordgapLabel() {
     std::wstring text = std::to_wstring(value);
     SetWindowText(hLabelWordgap_, text.c_str());
 }
+
+void MainDialog::UpdateVolumeLabel() {
+    int value = SendMessage(hSliderVolume_, TBM_GETPOS, 0, 0);
+    std::wstring text = std::to_wstring(value);
+    SetWindowText(hLabelVolume_, text.c_str());
+}
+
+
 
 void MainDialog::UpdateUIState() {
     bool defaultOnly = (SendMessage(hCheckDefaultOnly_, BM_GETCHECK, 0, 0) == BST_CHECKED);

--- a/configurator/MainDialog.hpp
+++ b/configurator/MainDialog.hpp
@@ -38,6 +38,7 @@ private:
     void PopulateProfileList();
     void UpdateIntonationLabel();
     void UpdateWordgapLabel();
+    void UpdateVolumeLabel();
     void UpdateUIState();
 
     void OnSelectAll();
@@ -62,6 +63,8 @@ private:
     HWND hLabelIntonation_;
     HWND hSliderWordgap_;
     HWND hLabelWordgap_;
+    HWND hSliderVolume_;
+    HWND hLabelVolume_;
     HWND hCheckRateboost_;
     HWND hListProfiles_;
     HWND hBtnRemoveProfile_;

--- a/configurator/resource.h
+++ b/configurator/resource.h
@@ -15,10 +15,12 @@
 #define IDC_SLIDER_WORDGAP              1007
 #define IDC_LABEL_WORDGAP               1008
 #define IDC_CHECK_RATEBOOST             1009
-#define IDC_LIST_PROFILES               1010
-#define IDC_BTN_ADD_PROFILE             1011
-#define IDC_BTN_REMOVE_PROFILE          1012
-#define IDC_BTN_OPEN_FOLDER             1013
+#define IDC_SLIDER_VOLUME              1010
+#define IDC_LABEL_VOLUME               1011
+#define IDC_LIST_PROFILES               1012
+#define IDC_BTN_ADD_PROFILE             1013
+#define IDC_BTN_REMOVE_PROFILE          1014
+#define IDC_BTN_OPEN_FOLDER             1015
 
 #define IDC_EDIT_PROFILE_NAME           2000
 #define IDC_COMBO_BASE_VOICE            2001

--- a/configurator/resource.rc
+++ b/configurator/resource.rc
@@ -32,6 +32,12 @@ BEGIN
     LTEXT           "0", IDC_LABEL_WORDGAP, 410, 145, 40, 10
     LTEXT           "Pause between words (10ms units)",
                     IDC_STATIC, 250, 170, 200, 10
+
+    LTEXT           "Volume (0 muted - 100 normal):", IDC_STATIC, 250, 130, 100, 10
+    CONTROL         "", IDC_SLIDER_VOLUME, TRACKBAR_CLASS,
+                    TBS_AUTOTICKS | WS_TABSTOP, 250, 145, 150, 20
+    LTEXT           "0", IDC_LABEL_VOLUME, 410, 145, 40, 10
+
     CONTROL         "Rate boost (x3)", IDC_CHECK_RATEBOOST,
                     "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 250, 188, 200, 12
 

--- a/src/ISpTTSEngineImpl.cpp
+++ b/src/ISpTTSEngineImpl.cpp
@@ -400,6 +400,14 @@ STDMETHODIMP ISpTTSEngineImpl::Speak(
                 }
             }
 
+
+            config::ConfigManager& config_mgr = config::ConfigManager::getInstance();
+            config::Configuration cfg = config_mgr.getConfig();
+            int intonation = cfg.intonation;
+            int wordgap = cfg.wordgap;
+            bool rateboost = cfg.rateboost;
+            int config_volume = cfg.volume;
+
             int combined_rate = static_cast<int>(sapi_rate) + frag->State.RateAdj;
             combined_rate = std::clamp(combined_rate, MIN_RATE, MAX_RATE);
             int espeak_rate = combined_rate * RATE_TO_WPM_MULTIPLIER;
@@ -408,13 +416,7 @@ STDMETHODIMP ISpTTSEngineImpl::Speak(
             int espeak_pitch = BASE_PITCH + std::clamp(pitch_adj * PITCH_ADJ_MULTIPLIER, MIN_PITCH_ADJ, MAX_PITCH_ADJ);
 
             int volume_adj = (sapi_volume - MAX_VOLUME) + (frag->State.Volume - MAX_VOLUME);
-            int espeak_volume = std::clamp(static_cast<int>(sapi_volume) + volume_adj, MIN_VOLUME, MAX_VOLUME);
-
-            config::ConfigManager& config_mgr = config::ConfigManager::getInstance();
-            config::Configuration cfg = config_mgr.getConfig();
-            int intonation = cfg.intonation;
-            int wordgap = cfg.wordgap;
-            bool rateboost = cfg.rateboost;
+            int espeak_volume = std::clamp(static_cast<int>(sapi_volume) + volume_adj + (config_volume - 100), MIN_VOLUME, MAX_VOLUME);
 
             DEBUG_LOG("--- Parameters ---");
             DEBUG_LOG("  Rate: SAPI=%d -> eSpeak-range=%d%s", combined_rate, espeak_rate, rateboost ? " (will boost x3 at WPM level)" : "");

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -35,6 +35,7 @@ void parseGlobalSettingsSection(const json& j, Configuration& config) {
         config.intonation = settings.value("intonation", 50);
         config.wordgap = settings.value("wordgap", 0);
         config.rateboost = settings.value("rateboost", false);
+		        config.volume = settings.value("volume", 100);
     }
 }
 
@@ -61,6 +62,8 @@ void clampConfigValues(Configuration& config) {
 
     if (config.wordgap < limits::WORDGAP_MIN) config.wordgap = limits::WORDGAP_MIN;
     if (config.wordgap > limits::WORDGAP_MAX) config.wordgap = limits::WORDGAP_MAX;
+
+    config.volume = std::clamp(config.volume, limits::VOLUME_MIN, limits::VOLUME_MAX);
 }
 
 void parseConfiguration(const json& j, Configuration& config) {
@@ -113,6 +116,7 @@ Configuration ConfigManager::createDefaultConfig() {
     config.enabled_voices.clear();
     config.global_variant = "";
     config.intonation = 50;
+    config.volume = 100;
     config.voice_profiles.clear();
     return config;
 }
@@ -187,6 +191,7 @@ bool ConfigManager::save(const Configuration& config) {
         j["global_settings"]["intonation"] = config.intonation;
         j["global_settings"]["wordgap"] = config.wordgap;
         j["global_settings"]["rateboost"] = config.rateboost;
+        j["global_settings"]["volume"] = config.volume;
 
         json profiles = json::array();
         for (const auto& profile : config.voice_profiles) {
@@ -265,8 +270,8 @@ void ConfigManager::checkAndReload() {
                 parseConfiguration(j, new_config);
 
                 config_ = new_config;
-                DEBUG_LOG("ConfigManager: Config reloaded successfully (intonation=%d, wordgap=%d, rateboost=%d)",
-                          config_.intonation, config_.wordgap, config_.rateboost);
+                DEBUG_LOG("ConfigManager: Config reloaded successfully (intonation=%d, wordgap=%d, rateboost=%d, volume=%d)",
+                          config_.intonation, config_.wordgap, config_.rateboost, config.volume);
             }
             catch (const json::exception& e) {
                 DEBUG_LOG("ConfigManager: JSON error during reload: %s", e.what());

--- a/src/config_manager.hpp
+++ b/src/config_manager.hpp
@@ -14,6 +14,8 @@ namespace limits {
     constexpr int INTONATION_MAX = 100;
     constexpr int WORDGAP_MIN = 0;
     constexpr int WORDGAP_MAX = 100;
+    constexpr int VOLUME_MIN = 0;
+    constexpr int VOLUME_MAX = 100;
 }
 
 struct VoiceProfile {
@@ -42,6 +44,7 @@ struct Configuration {
     std::string global_variant;
     int intonation;
     int wordgap;
+    int volume;
     bool rateboost;
     std::vector<VoiceProfile> voice_profiles;
 


### PR DESCRIPTION
Makes it possible to set the default volume from the configurator, because many games will not allow changing the volume and it's way too loud, such as Aprone's games and some of Kitchen'sinc.
* Add slider and label to configurator
* Add to .rc
* pass it along to espeak-ng
